### PR TITLE
Add support for NonPackaged webcam apps

### DIFF
--- a/CameraDetectionService.cs
+++ b/CameraDetectionService.cs
@@ -62,12 +62,34 @@ namespace TeamsPresence
 
             foreach (var app in key.GetSubKeyNames())
             {
-                var lastUsedTimeStop = Registry.CurrentUser.OpenSubKey($@"{SubKey}\{app}")?.GetValue("LastUsedTimeStop");
-
-                if (lastUsedTimeStop != null && (long)lastUsedTimeStop == 0)
+                if (app == "NonPackaged")
                 {
-                    return app;
+                    var nonPackagedKeys = Registry.CurrentUser.OpenSubKey($@"{SubKey}\{app}");
+
+                    foreach (var packageKey in nonPackagedKeys.GetSubKeyNames())
+                    {
+                        var lastUsedTimeStop = Registry.CurrentUser.OpenSubKey($@"{SubKey}\{app}\{packageKey}")?.GetValue("LastUsedTimeStop");
+
+
+                        if (lastUsedTimeStop != null && (long)lastUsedTimeStop == 0)
+                        {
+                            var tokens = packageKey.Split('#');
+
+                            return tokens.Last();
+                        }
+                    }
                 }
+                else
+                {
+                    var lastUsedTimeStop = Registry.CurrentUser.OpenSubKey($@"{SubKey}\{app}")?.GetValue("LastUsedTimeStop");
+
+
+                    if (lastUsedTimeStop != null && (long)lastUsedTimeStop == 0)
+                    {
+                        return app;
+                    }
+                }
+
             }
 
             return "";

--- a/HomeAssistantEntityStateUpdateAttributes.cs
+++ b/HomeAssistantEntityStateUpdateAttributes.cs
@@ -6,7 +6,7 @@ namespace TeamsPresence
     {
         [JsonProperty(PropertyName = "friendly_name")]
         public string FriendlyName { get; set; }
-        [JsonProperty(PropertyName = "state")]
+        [JsonProperty(PropertyName = "icon")]
         public string Icon { get; set; }
     }
 }


### PR DESCRIPTION
I think it is because I am using the work/school version of Teams, but it shows up differently in the registry:
![image](https://user-images.githubusercontent.com/83248080/234894065-b7b1f5e9-3c1b-43df-8541-59d26f1a8449.png)


I tested and confirmed that these changes work and display in HA nicely:
![image](https://user-images.githubusercontent.com/83248080/234894238-d256e5a9-d03c-4e9b-b720-778907e563a0.png)
