### PR TITLE
Using correct JSON property name for icon

### DIFF
--- a/HomeAssistantEntityStateUpdateAttributes.cs
+++ b/HomeAssistantEntityStateUpdateAttributes.cs
@@ -6,7 +6,8 @@ namespace TeamsPresence
     {
         [JsonProperty(PropertyName = "friendly_name")]
         public string FriendlyName { get; set; }
-        [JsonProperty(PropertyName = "state")]
+
+        [JsonProperty(PropertyName = "icon")]
         public string Icon { get; set; }
     }
 }


### PR DESCRIPTION
The property `Icon` in the `HomeAssistantEntityStateUpdateAttributes` class has an incorrect `[JsonProperty]` value, updated this to match the attribute.