### PR TITLE
Updating friendly_name to use the correct value

### DIFF
--- a/HomeAssistantEntityStateUpdateAttributes.cs
+++ b/HomeAssistantEntityStateUpdateAttributes.cs
@@ -6,7 +6,8 @@ namespace TeamsPresence
     {
         [JsonProperty(PropertyName = "friendly_name")]
         public string FriendlyName { get; set; }
-        [JsonProperty(PropertyName = "state")]
+
+        [JsonProperty(PropertyName = "icon")]
         public string Icon { get; set; }
     }
 }

--- a/HomeAssistantEntityStateUpdateAttributes.cs
+++ b/HomeAssistantEntityStateUpdateAttributes.cs
@@ -5,7 +5,7 @@ namespace TeamsPresence
     public class HomeAssistantEntityStateUpdateAttributes
     {
         [JsonProperty(PropertyName = "friendly_name")]
-        public string FriendlyName { get; set; }
+        public string EntityFriendlyName { get; set; }
 
         [JsonProperty(PropertyName = "icon")]
         public string Icon { get; set; }

--- a/HomeAssistantService.cs
+++ b/HomeAssistantService.cs
@@ -5,28 +5,24 @@ namespace TeamsPresence
 {
     public class HomeAssistantService
     {
-        private string Token { get; set; }
-        private string Url { get; set; }
         private RestClient Client { get; set; }
 
         public HomeAssistantService(string url, string token)
         {
-            Token = token;
-            Url = url;
             Client = new RestClient(url);
 
-            Client.AddDefaultHeader("Authorization", $"Bearer {Token}");
+            Client.AddDefaultHeader("Authorization", $"Bearer {token}");
             Client.UseNewtonsoftJson();
         }
 
-        public void UpdateEntity(string entity, string state, string stateFriendlyName, string icon)
+        public void UpdateEntity(string entity, string entityFriendlyName, string state, string icon)
         {
             var update = new HomeAssistantEntityStateUpdate()
             {
                 State = state,
                 Attributes = new HomeAssistantEntityStateUpdateAttributes()
                 {
-                    FriendlyName = stateFriendlyName,
+                    EntityFriendlyName = entityFriendlyName,
                     Icon = icon
                 }
             };

--- a/Program.cs
+++ b/Program.cs
@@ -3,12 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Resources;
-using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace TeamsPresence
@@ -59,54 +54,7 @@ namespace TeamsPresence
             {
                 Console.WriteLine("Config file doesn't exist. Creating...");
 
-                Config = new TeamsPresenceConfig()
-                {
-                    HomeAssistantUrl = "https://yourha.duckdns.org",
-                    HomeAssistantToken = "eyJ0eXAiOiJKV1...",
-                    AppDataRoamingPath = "",
-                    StatusEntity = "sensor.teams_presence_status",
-                    ActivityEntity = "sensor.teams_presence_activity",
-                    CameraAppEntity = "sensor.teams_presence_camera_app",
-                    CameraStatusEntity = "sensor.teams_presence_camera_status",
-                    CameraStatusPollingRate = 1000,
-                    FriendlyStatusNames = new Dictionary<TeamsStatus, string>()
-                    {
-                        { TeamsStatus.Available, "Available" },
-                        { TeamsStatus.Busy, "Busy" },
-                        { TeamsStatus.OnThePhone, "On the phone" },
-                        { TeamsStatus.Away, "Away" },
-                        { TeamsStatus.BeRightBack, "Be right back" },
-                        { TeamsStatus.DoNotDisturb, "Do not disturb" },
-                        { TeamsStatus.Presenting, "Presenting" },
-                        { TeamsStatus.Focusing, "Focusing" },
-                        { TeamsStatus.InAMeeting, "In a meeting" },
-                        { TeamsStatus.Offline, "Offline" },
-                        { TeamsStatus.Unknown, "Unknown" }
-                    },
-                    FriendlyActivityNames = new Dictionary<TeamsActivity, string>()
-                    {
-                        { TeamsActivity.InACall, "In a call" },
-                        { TeamsActivity.NotInACall, "Not in a call" },
-                        { TeamsActivity.Unknown, "Unknown" }
-                    },
-                    FriendlyCameraStatusNames = new Dictionary<CameraStatus, string>()
-                    {
-                        { CameraStatus.Inactive, "Inactive" },
-                        { CameraStatus.Active, "Active" }
-                    },
-                    ActivityIcons = new Dictionary<TeamsActivity, string>()
-                    {
-                        { TeamsActivity.InACall, "mdi:phone-in-talk-outline" },
-                        { TeamsActivity.NotInACall, "mdi:phone-off" },
-                        { TeamsActivity.Unknown, "mdi:phone-cancel" }
-                    },
-                    CameraStatusIcons = new Dictionary<CameraStatus, string>()
-                    {
-                        { CameraStatus.Inactive, "mdi:webcam-off" },
-                        { CameraStatus.Active, "mdi:webcam" }
-                    },
-                    CameraAppIcon = "mdi:application"
-                };
+                Config = GenerateDefaultConfig();
 
                 File.WriteAllText(configFilePath, JsonConvert.SerializeObject(Config, new JsonSerializerSettings()
                 {
@@ -151,6 +99,62 @@ namespace TeamsPresence
             cameraDetectionThread.Start();
 
             Application.Run();
+        }
+
+        private static TeamsPresenceConfig GenerateDefaultConfig()
+        {
+            return new TeamsPresenceConfig()
+            {
+                HomeAssistantUrl = "https://yourha.duckdns.org",
+                HomeAssistantToken = "eyJ0eXAiOiJKV1...",
+                AppDataRoamingPath = "",
+                StatusEntity = "sensor.teams_presence_status",
+                StatusEntityFriendlyName = "Microsoft Teams status",
+                ActivityEntity = "sensor.teams_presence_activity",
+                ActivityEntityFriendlyName = "Microsoft Teams activity",
+                CameraAppEntity = "sensor.teams_presence_camera_app",
+                CameraAppEntityFriendlyName = "Microsoft Teams camera app",
+                CameraStatusEntity = "sensor.teams_presence_camera_status",
+                CameraStatusEntityFriendlyName = "Microsoft Teams camera status",
+                CameraStatusPollingRate = 1000,
+                FriendlyStatusNames = new Dictionary<TeamsStatus, string>()
+                    {
+                        { TeamsStatus.Available, "Available" },
+                        { TeamsStatus.Busy, "Busy" },
+                        { TeamsStatus.OnThePhone, "On the phone" },
+                        { TeamsStatus.Away, "Away" },
+                        { TeamsStatus.BeRightBack, "Be right back" },
+                        { TeamsStatus.DoNotDisturb, "Do not disturb" },
+                        { TeamsStatus.Presenting, "Presenting" },
+                        { TeamsStatus.Focusing, "Focusing" },
+                        { TeamsStatus.InAMeeting, "In a meeting" },
+                        { TeamsStatus.Offline, "Offline" },
+                        { TeamsStatus.Unknown, "Unknown" }
+                    },
+                FriendlyActivityNames = new Dictionary<TeamsActivity, string>()
+                    {
+                        { TeamsActivity.InACall, "In a call" },
+                        { TeamsActivity.NotInACall, "Not in a call" },
+                        { TeamsActivity.Unknown, "Unknown" }
+                    },
+                FriendlyCameraStatusNames = new Dictionary<CameraStatus, string>()
+                    {
+                        { CameraStatus.Inactive, "Inactive" },
+                        { CameraStatus.Active, "Active" }
+                    },
+                ActivityIcons = new Dictionary<TeamsActivity, string>()
+                    {
+                        { TeamsActivity.InACall, "mdi:phone-in-talk-outline" },
+                        { TeamsActivity.NotInACall, "mdi:phone-off" },
+                        { TeamsActivity.Unknown, "mdi:phone-cancel" }
+                    },
+                CameraStatusIcons = new Dictionary<CameraStatus, string>()
+                    {
+                        { CameraStatus.Inactive, "mdi:webcam-off" },
+                        { CameraStatus.Active, "mdi:webcam" }
+                    },
+                CameraAppIcon = "mdi:application"
+            };
         }
 
         private static void SetupNotifyIcon()
@@ -200,25 +204,41 @@ namespace TeamsPresence
 
         private static void Service_StatusChanged(object sender, TeamsStatus status)
         {
-            HomeAssistantService.UpdateEntity(Config.StatusEntity, Config.FriendlyStatusNames[status], Config.FriendlyStatusNames[status], "mdi:microsoft-teams");
+            HomeAssistantService.UpdateEntity(
+                Config.StatusEntity,
+                Config.StatusEntityFriendlyName,
+                Config.FriendlyStatusNames[status],
+                "mdi:microsoft-teams");
 
             Console.WriteLine($"Updated status to {Config.FriendlyStatusNames[status]} ({status})");
         }
 
         private static void Service_ActivityChanged(object sender, TeamsActivity activity)
         {
-            HomeAssistantService.UpdateEntity(Config.ActivityEntity, Config.FriendlyActivityNames[activity], Config.FriendlyActivityNames[activity], Config.ActivityIcons[activity]);
+            HomeAssistantService.UpdateEntity(
+                Config.ActivityEntity,
+                Config.ActivityEntityFriendlyName,
+                Config.FriendlyActivityNames[activity],
+                Config.ActivityIcons[activity]);
 
             Console.WriteLine($"Updated activity to {Config.FriendlyActivityNames[activity]} ({activity})");
         }
 
         private static void Camera_StatusChanged(object sender, CameraStatusChangedEventArgs args)
         {
-            HomeAssistantService.UpdateEntity(Config.CameraStatusEntity, Config.FriendlyCameraStatusNames[args.Status], Config.FriendlyCameraStatusNames[args.Status], Config.CameraStatusIcons[args.Status]);
+            HomeAssistantService.UpdateEntity(
+                Config.CameraStatusEntity,
+                Config.CameraStatusEntityFriendlyName,
+                Config.FriendlyCameraStatusNames[args.Status],
+                Config.CameraStatusIcons[args.Status]);
 
             Console.WriteLine($"Updated camera status to {args.Status}");
 
-            HomeAssistantService.UpdateEntity(Config.CameraAppEntity, args.AppName, args.AppName, Config.CameraAppIcon);
+            HomeAssistantService.UpdateEntity(
+                Config.CameraAppEntity,
+                Config.CameraAppEntityFriendlyName,
+                args.AppName,
+                Config.CameraAppIcon);
 
             Console.WriteLine($"Updated camera app to {args.AppName}");
         }

--- a/README.md
+++ b/README.md
@@ -7,29 +7,11 @@ When you run the application for the first time it will create a sample `config.
 
 **Note:** You can set the `AppDataRoamingPath` to hard code which user profile is used for `%appdata%`
 
-Some changes to Home Assistant's config is also needed. Add the following to your `configuration.yaml`:
+No changes are required to Home Assistant's config. This application will populate the following sensors by default (identifiers and friendly names can be changed in the `config.json` file):
 
-```yaml
-sensor:
-    - platform: template
-      sensors:
-        teams_status:
-            friendly_name: "Microsoft Teams status"
-            value_template: "{{states('input_text.teams_status')}}"
-            icon_template: "{{state_attr('input_text.teams_status','icon')}}"
-            unique_id: sensor.teams_status
-        teams_activity:
-            friendly_name: "Microsoft Teams activity"
-            value_template: "{{states('input_text.teams_activity')}}"
-            unique_id: sensor.teams_activity
+- `sensor.teams_presence_status`
+- `sensor.teams_presence_activity`
+- `sensor.teams_presence_camera_app`
+- `sensor.teams_presence_camera_status`
 
-input_text:
-    teams_status:
-        name: Microsoft Teams Status
-        icon: mdi:microsoft-teams
-    teams_activity:
-        name: Microsoft Teams Activity
-        icon: mdi:phone-off
-```
-
-Once these steps are completed, you should be able to start the application and see changes to your Teams status and call activity get updated both in the console and in Home Assistant.
+Once this step is completed, you should be able to start the application and see changes to your Teams status and call activity get updated both in the console and in Home Assistant.

--- a/TeamsPresenceConfig.cs
+++ b/TeamsPresenceConfig.cs
@@ -13,9 +13,13 @@ namespace TeamsPresence
         public string AppDataRoamingPath { get; set; }
 
         public string StatusEntity { get; set; }
+        public string StatusEntityFriendlyName { get; set; }
         public string ActivityEntity { get; set; }
+        public string ActivityEntityFriendlyName { get; set; }
         public string CameraStatusEntity { get; set; }
+        public string CameraStatusEntityFriendlyName { get; set; }
         public string CameraAppEntity { get; set; }
+        public string CameraAppEntityFriendlyName { get; set; }
 
         public int CameraStatusPollingRate { get; set; }
 


### PR DESCRIPTION
The `friendly_name` attribute is not used for the state's friendly name but the entity's friendly name, this is now updated using configuration items for these friendly names. Furthermore the README reflected an old way of working: the `input_texts` were no longer used in code.